### PR TITLE
Update installation script for Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install --save-dev bs-enzyme enzyme-adapter-react-16
 With Yarn:
 
 ```sh
-yarn add bs-enzyme enzyme-adapter-react-16
+yarn add --dev bs-enzyme enzyme-adapter-react-16
 ```
 
 Then add `bs-enzyme` to `bs-dev-dependencies` in your `bsconfig.json`:


### PR DESCRIPTION
The current example installation command inserts packages as a devDependency for NPM and a regular dependency for Yarn. 

Unless there's some quirk, I imagine these should probably both be devDependencies.